### PR TITLE
fix typo in SASS variable names: 'archieve' --> 'archive'

### DIFF
--- a/sass/base/_color.scss
+++ b/sass/base/_color.scss
@@ -4,7 +4,7 @@ $color-blog-title: #3498db !default;
 $color-blog-title-h: #e74c3c !default;
 $color-blog-subtitle: #34495e !default;
 
-$color-archieve-title: #34495e !default;
+$color-archive-title: #34495e !default;
 $color-article-title: #e74c3c !default;
 $color-blog-body: #555 !default;
 $color-tag: #3498db !default;

--- a/sass/base/_layout.scss
+++ b/sass/base/_layout.scss
@@ -52,9 +52,9 @@ h3{
 	@media screen and (max-width: 620px) {
 	font-size: 15px;
 	}
-    
+
     a{
-	color: $color-archieve-title;
+	color: $color-archive-title;
         font-weight: bold;
 	@include transition(color 0.3s);
 	&:hover{
@@ -62,7 +62,7 @@ h3{
 		border-bottom:none;
                }
      }
-    
+
 }
 
 a.category {


### PR DESCRIPTION
Obviously not a big deal, but I like fixing typos where I can!

Loving this theme, by the way!
